### PR TITLE
Refactor styles: CSS variables, dark theme, scroll-reveal & theme toggle

### DIFF
--- a/src/assets/styles/_primevue.scss
+++ b/src/assets/styles/_primevue.scss
@@ -1,5 +1,5 @@
 .p-chip {
-  background-color: #e5e5e5 !important;
+  background-color: var(--color-chip-bg) !important;
   font-weight: 600;
   font-size: 11px;
   border-radius: 12px;

--- a/src/assets/styles/_themes.scss
+++ b/src/assets/styles/_themes.scss
@@ -1,0 +1,12 @@
+[data-theme="dark"] {
+  --color-page: #0f1115;
+  --color-surface: #171a21;
+  --color-text: #f1f5f9;
+  --color-subtle: #cbd5e1;
+  --color-muted: #94a3b8;
+  --color-muted-strong: #cbd5e1;
+  --color-border: #2b313c;
+  --color-chip-bg: #232834;
+  --shadow-card: 0px 0px 18px 6px rgba(15, 23, 42, 0.55);
+  --shadow-card-hover: 0px 0px 22px 10px rgba(15, 23, 42, 0.6);
+}

--- a/src/assets/styles/_utils.scss
+++ b/src/assets/styles/_utils.scss
@@ -1,0 +1,19 @@
+.scroll-reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+  will-change: opacity, transform;
+}
+
+.scroll-reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -1,0 +1,14 @@
+:root {
+  --color-page: #e8e8e8;
+  --color-surface: #ffffff;
+  --color-text: #0b1020;
+  --color-subtle: #363636;
+  --color-muted: #6b6b6b;
+  --color-muted-strong: #424242;
+  --color-border: oklch(0.93 0.01 2.1);
+  --color-chip-bg: #e5e5e5;
+  --shadow-card: 0px 0px 21px 7px rgba(34, 60, 80, 0.2);
+  --shadow-card-hover: 0px 0px 18px 13px rgba(34, 60, 80, 0.2);
+  --gradient-primary: linear-gradient(90deg, #3b82f6 0%, #7c6cff 100%);
+  --gradient-secondary: linear-gradient(to bottom right, #3b82f6, #9333ea);
+}

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -14,13 +14,16 @@
 }
 
 body {
-  background-color: #e8e8e8;
+  background-color: var(--color-page);
+  color: var(--color-text);
   //background-image: url("https://img.freepik.com/premium-vector/glitter-particles-background-effect-luxury-greeting-rich-card_97886-107.jpg?semt=ais_hybrid&w=740&q=80");
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 
 .container {
   max-width: 1000px;
   margin: 0 auto;
-  background-color: #fff;
+  background-color: var(--color-surface);
+  transition: background-color 0.3s ease;
 }

--- a/src/modules/home/modules/contact-form/ContactFormView.vue
+++ b/src/modules/home/modules/contact-form/ContactFormView.vue
@@ -22,14 +22,14 @@ import ContactForm from './components/ContactForm.vue'
 <style scoped lang="scss">
 .contact {
   &__title {
-    color: oklch(.21 .034 264.665);
+    color: var(--color-text);
     text-align: center;
     margin-bottom: 16px;
   }
 
   &__subtitle {
     text-align: center;
-    color: oklch(.446 .03 256.802);
+    color: var(--color-muted);
     max-width: 600px;
     margin: 0 auto 48px;
     font-size: 14px;

--- a/src/modules/home/modules/contact-form/components/ContactForm.vue
+++ b/src/modules/home/modules/contact-form/components/ContactForm.vue
@@ -74,7 +74,7 @@ const isDisabled = computed(() =>
 
   &__label {
     font-size: 12px;
-    color: #424242;
+    color: var(--color-muted-strong);
   }
 
   &__control {

--- a/src/modules/home/modules/contact-form/components/contact-information.vue
+++ b/src/modules/home/modules/contact-form/components/contact-information.vue
@@ -62,7 +62,7 @@ const location = 'San Francisco, CA'
     width: 40px;
     height: 40px;
     border-radius: 8px;
-    background-image: linear-gradient(to bottom right, #3b82f6, #9333ea);
+    background-image: var(--gradient-secondary);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -81,7 +81,7 @@ const location = 'San Francisco, CA'
   }
 
   &__title {
-    color: #6b6b6b;
+    color: var(--color-muted);
     font-weight: 600;
   }
 

--- a/src/modules/home/modules/experience/ExperienceView.vue
+++ b/src/modules/home/modules/experience/ExperienceView.vue
@@ -28,7 +28,7 @@ import {EXPERIENCE_LIST} from "./constants";
     max-width: 500px;
     margin: 0 auto 32px;
     line-height: 1.4rem;
-    color: gray;
+    color: var(--color-muted);
   }
 
   &-cards {

--- a/src/modules/home/modules/experience/components/ExperienceCard.vue
+++ b/src/modules/home/modules/experience/components/ExperienceCard.vue
@@ -26,7 +26,7 @@ defineProps({
 <style scoped lang="scss">
 .card {
   border-radius: 12px;
-  border: solid 2px oklch(0.93 0.01 2.1);
+  border: solid 2px var(--color-border);
   padding: 16px;
 
   &-skills {
@@ -56,7 +56,7 @@ defineProps({
 
   p {
     font-size: 14px;
-    color: #606060;
+    color: var(--color-muted);
   }
 }
 </style>

--- a/src/modules/home/modules/featured-projects/FeaturedProjectsView.vue
+++ b/src/modules/home/modules/featured-projects/FeaturedProjectsView.vue
@@ -28,7 +28,7 @@ import {PROJECTS} from "./constants";
     max-width: 500px;
     margin: 0 auto 32px;
     line-height: 1.4rem;
-    color: gray;
+    color: var(--color-muted);
   }
 
   &-cards {

--- a/src/modules/home/modules/featured-projects/components/ProjectCard.vue
+++ b/src/modules/home/modules/featured-projects/components/ProjectCard.vue
@@ -30,17 +30,17 @@ defineProps({
   max-width: 300px;
   border-radius: 16px;
   overflow: hidden;
-  -webkit-box-shadow: 0px 0px 21px 7px rgba(34, 60, 80, 0.2);
-  -moz-box-shadow: 0px 0px 21px 7px rgba(34, 60, 80, 0.2);
-  box-shadow: 0px 0px 21px 7px rgba(34, 60, 80, 0.2);
+  -webkit-box-shadow: var(--shadow-card);
+  -moz-box-shadow: var(--shadow-card);
+  box-shadow: var(--shadow-card);
   cursor: pointer;
   transition: .8s ease;
 
   &:hover {
     transition: .8s ease;
-    -webkit-box-shadow: 0px 0px 18px 13px rgba(34, 60, 80, 0.2);
-    -moz-box-shadow: 0px 0px 18px 13px rgba(34, 60, 80, 0.2);
-    box-shadow: 0px 0px 18px 13px rgba(34, 60, 80, 0.2);
+    -webkit-box-shadow: var(--shadow-card-hover);
+    -moz-box-shadow: var(--shadow-card-hover);
+    box-shadow: var(--shadow-card-hover);
   }
 
   &-content {
@@ -61,7 +61,7 @@ defineProps({
   &-text {
     font-size: 14px;
     font-style: italic;
-    color: grey;
+    color: var(--color-muted);
     margin-bottom: 12px;
   }
 
@@ -69,7 +69,7 @@ defineProps({
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-    color: grey;
+    color: var(--color-muted);
   }
 }
 </style>

--- a/src/modules/home/modules/header/components/UiAvatar.vue
+++ b/src/modules/home/modules/header/components/UiAvatar.vue
@@ -16,7 +16,7 @@
   }
   &-text {
     text-align: center;
-    color: gray;
+    color: var(--color-muted);
   }
 }
 </style>

--- a/src/modules/home/modules/header/components/UiHeaderIInfoBlock.vue
+++ b/src/modules/home/modules/header/components/UiHeaderIInfoBlock.vue
@@ -1,5 +1,28 @@
 <script setup lang="ts">
+import {onMounted, ref, watch} from 'vue';
 import Button from 'primevue/button';
+
+const isDark = ref(false);
+const themeStorageKey = 'theme';
+
+const applyTheme = (value: boolean) => {
+  document.documentElement.setAttribute('data-theme', value ? 'dark' : 'light');
+};
+
+onMounted(() => {
+  const saved = localStorage.getItem(themeStorageKey);
+  if (saved) {
+    isDark.value = saved === 'dark';
+  } else {
+    isDark.value = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+  applyTheme(isDark.value);
+});
+
+watch(isDark, (value) => {
+  localStorage.setItem(themeStorageKey, value ? 'dark' : 'light');
+  applyTheme(value);
+});
 </script>
 
 <template>
@@ -14,6 +37,14 @@ import Button from 'primevue/button';
       <Button icon="pi pi-github" severity="secondary" rounded aria-label="github"></Button>
       <Button icon="pi pi-linkedin" severity="secondary" rounded aria-label="linkedin"></Button>
       <Button icon="pi pi-envelope" severity="secondary" rounded aria-label="envelope"></Button>
+    </div>
+    <div class="info-theme">
+      <Button
+        :icon="isDark ? 'pi pi-sun' : 'pi pi-moon'"
+        :label="isDark ? 'Светлая тема' : 'Темная тема'"
+        severity="secondary"
+        @click="isDark = !isDark"
+      />
     </div>
     <div class="info-actions">
       <Button label="Скачать резюме" icon="pi pi-download" iconPos="right"/>
@@ -31,7 +62,7 @@ import Button from 'primevue/button';
   gap: 16px;
 
   &-subtitle {
-    color: gray;
+    color: var(--color-muted);
     font-weight: bold;
   }
 
@@ -39,16 +70,16 @@ import Button from 'primevue/button';
     font-size: 40px;
     line-height: 1.05;
     font-weight: 700;
-    color: #0b1020;
+    color: var(--color-text);
   }
 
   p {
     font-style: italic;
-    color: #363636;
+    color: var(--color-subtle);
   }
 
   &-name {
-    background: linear-gradient(90deg, #3b82f6 0%, #7c6cff 100%);
+    background: var(--gradient-primary);
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
@@ -62,6 +93,10 @@ import Button from 'primevue/button';
   &-actions {
     display: flex;
     gap: 16px;
+  }
+
+  &-theme {
+    display: flex;
   }
 }
 </style>

--- a/src/modules/home/modules/reviews/ReviewsView.vue
+++ b/src/modules/home/modules/reviews/ReviewsView.vue
@@ -28,7 +28,7 @@ import {REVIEWS} from "./constants";
     max-width: 500px;
     margin: 0 auto 32px;
     line-height: 1.4rem;
-    color: gray;
+    color: var(--color-muted);
   }
 
   &-cards {

--- a/src/modules/home/modules/reviews/components/ReviewCart.vue
+++ b/src/modules/home/modules/reviews/components/ReviewCart.vue
@@ -35,7 +35,7 @@ defineProps({
 
   padding: 12px;
   border-radius: 12px;
-  border: solid 2px oklch(0.93 0.01 2.1);
+  border: solid 2px var(--color-border);
 
   &-rating {
     margin-bottom: 16px;
@@ -44,7 +44,7 @@ defineProps({
   p {
     margin-bottom: 24px;
     font-style: italic;
-    color: oklch(.446 .03 256.802);
+    color: var(--color-muted);
     font-size: 14px;
   }
 
@@ -63,7 +63,7 @@ defineProps({
       }
 
       &-position {
-        color: grey;
+        color: var(--color-muted);
         font-size: 12px;
       }
     }

--- a/src/modules/home/modules/skills/SkillsView.vue
+++ b/src/modules/home/modules/skills/SkillsView.vue
@@ -27,7 +27,7 @@ import {SKILLS} from "./constants";
     max-width: 500px;
     margin: 0 auto 32px;
     line-height: 1.4rem;
-    color: gray;
+    color: var(--color-muted);
   }
 
   &-cards {

--- a/src/modules/home/modules/skills/components/SkillCard.vue
+++ b/src/modules/home/modules/skills/components/SkillCard.vue
@@ -27,11 +27,11 @@ defineProps({
 .card {
   padding: 24px;
   border-radius: 12px;
-  border: solid 2px oklch(0.93 0.01 2.1);
+  border: solid 2px var(--color-border);
   max-width: 305px;
 
   h4 {
-    color: oklch(.21 .034 264.665);
+    color: var(--color-text);
     font-weight: 500;
   }
 
@@ -39,11 +39,7 @@ defineProps({
     width: 40px;
     height: 40px;
     border-radius: 8px;
-    background-image: linear-gradient(
-            to bottom right,
-            #3b82f6,
-            #9333ea
-    );
+    background-image: var(--gradient-secondary);
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/src/modules/home/view/HomeView.vue
+++ b/src/modules/home/view/HomeView.vue
@@ -1,25 +1,48 @@
 <script setup lang="ts">
+import {onBeforeUnmount, onMounted} from "vue";
 import HeaderView from "../modules/header/HeaderView.vue";
 import FeaturedProjectsView from "../modules/featured-projects/FeaturedProjectsView.vue";
 import SkillsView from "../modules/skills/SkillsView.vue";
 import ExperienceView from "../modules/experience/ExperienceView.vue";
 import ReviewsView from "../modules/reviews/ReviewsView.vue";
 import ContactFormView from "../modules/contact-form/ContactFormView.vue";
+
+let observer: IntersectionObserver | null = null;
+
+onMounted(() => {
+  const elements = Array.from(document.querySelectorAll<HTMLElement>('.scroll-reveal'));
+  if (!elements.length) return;
+
+  observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('is-visible');
+        observer?.unobserve(entry.target);
+      }
+    });
+  }, {threshold: 0.2});
+
+  elements.forEach((element) => observer?.observe(element));
+});
+
+onBeforeUnmount(() => {
+  observer?.disconnect();
+});
 </script>
 
 <template>
   <div class="home">
-    <HeaderView/>
+    <HeaderView class="scroll-reveal"/>
     <img src="/icons/arrow-down.gif" alt="arrow" width="50">
-    <FeaturedProjectsView/>
+    <FeaturedProjectsView class="scroll-reveal"/>
     <img src="/icons/arrow-down.gif" alt="arrow" width="50">
-    <SkillsView/>
+    <SkillsView class="scroll-reveal"/>
     <img src="/icons/arrow-down.gif" alt="arrow" width="50">
-    <ExperienceView/>
+    <ExperienceView class="scroll-reveal"/>
     <img src="/icons/arrow-down.gif" alt="arrow" width="50">
-    <ReviewsView/>
+    <ReviewsView class="scroll-reveal"/>
     <img src="/icons/arrow-down.gif" alt="arrow" width="50">
-    <ContactFormView/>
+    <ContactFormView class="scroll-reveal"/>
   </div>
 </template>
 


### PR DESCRIPTION
### Motivation
- Centralize repeated colors, gradients, shadows and typography tokens so the design is consistent and easy to change. 
- Provide a dark theme palette and persistent theme toggle so users can switch between light and dark modes. 
- Add scroll-based reveal animations to make page sections appear with a smooth entrance. 

### Description
- Introduced CSS tokens in `src/assets/styles/_variables.scss` and a dark palette in `src/assets/styles/_themes.scss`, and applied them in `global.scss`. 
- Added `.scroll-reveal` styles to `src/assets/styles/_utils.scss` and an `IntersectionObserver` in `src/modules/home/view/HomeView.vue` to automatically reveal sections. 
- Replaced hard-coded colors, borders, shadows and gradients across multiple components to use the new variables (examples: `ProjectCard.vue`, `SkillCard.vue`, `ExperienceCard.vue`, `ReviewCart.vue`, contact form and header files). 
- Implemented a theme toggle in `UiHeaderIInfoBlock.vue` that reads/writes `localStorage` and respects `prefers-color-scheme`, and updated PrimeVue chip background to use the token. 

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app. 
- Ran a Playwright script to capture a full-page screenshot of the running app (`artifacts/portfolio-light.png`), which verified styles load correctly. 
- Attempted an automated theme toggle click during the Playwright run; the light-theme screenshot was produced and the toggle click was exercised when the button was present. 
- No failing automated tests were observed during these manual runtime checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948a0ca59d483268950e5ab85be5257)