### PR TITLE
Add scroll-reveal directive and animations for section cards

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -24,3 +24,23 @@ body {
   margin: 0 auto;
   background-color: #fff;
 }
+
+.reveal-on-scroll {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+  will-change: opacity, transform;
+}
+
+.reveal-on-scroll.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-on-scroll {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,36 @@ import DialogService from 'primevue/dialogservice';
 import {PRIME_VUE_CONFIG} from "../primevue.config.ts";
 import {router} from "./router";
 
-createApp(App)
+const app = createApp(App)
+
+app.directive('reveal-on-scroll', {
+    mounted(el) {
+        const target = el as HTMLElement & { _revealObserver?: IntersectionObserver }
+        target.classList.add('reveal-on-scroll')
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('is-visible')
+                        observer.unobserve(entry.target)
+                    }
+                })
+            },
+            {threshold: 0.2}
+        )
+        observer.observe(target)
+        target._revealObserver = observer
+    },
+    unmounted(el) {
+        const target = el as HTMLElement & { _revealObserver?: IntersectionObserver }
+        if (target._revealObserver) {
+            target._revealObserver.disconnect()
+            delete target._revealObserver
+        }
+    }
+})
+
+app
     .use(router)
     .use(PrimeVue, PRIME_VUE_CONFIG)
     .use(DialogService)

--- a/src/modules/home/modules/contact-form/api/index.ts
+++ b/src/modules/home/modules/contact-form/api/index.ts
@@ -1,0 +1,21 @@
+import type {IPayloadForm} from "../interfaces";
+
+export async function sendToTelegramDirect(form: IPayloadForm) {
+    const BOT_TOKEN = "8523996263:AAHqYmJOcSW1zcRySftlQBb_Oe_yLDrFuI4"; // будет виден всем
+    const CHAT_ID = "5000816492";
+
+    const text =
+        `📩 New message\n\n` +
+        `👤 ${form.username}\n` +
+        `📧 ${form.email}\n\n` +
+        `💬 ${form.message}`;
+
+    const res = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: CHAT_ID, text }),
+    });
+
+    const data = await res.json();
+    if (!data?.ok) throw new Error("Telegram error");
+}

--- a/src/modules/home/modules/contact-form/components/ContactForm.vue
+++ b/src/modules/home/modules/contact-form/components/ContactForm.vue
@@ -4,6 +4,7 @@ import InputText from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
 import Button from 'primevue/button'
 import type {IPayloadForm} from "../interfaces";
+import {sendToTelegramDirect} from "../api";
 
 const form = ref<IPayloadForm>({
   username: '',
@@ -14,6 +15,17 @@ const form = ref<IPayloadForm>({
 const isDisabled = computed(() =>
     Object.values(form.value).some((v) => !String(v).trim())
 )
+
+function sendForm() {
+  sendToTelegramDirect(form.value)
+      .then(() => {
+        form.value = {
+          username: '',
+          email: '',
+          message: '',
+        }
+      })
+}
 </script>
 
 <template>
@@ -55,6 +67,7 @@ const isDisabled = computed(() =>
         iconPos="right"
         :disabled="isDisabled"
         class="contact-form__submit"
+        @click="sendForm()"
     />
   </form>
 </template>

--- a/src/modules/home/modules/experience/components/ExperienceCard.vue
+++ b/src/modules/home/modules/experience/components/ExperienceCard.vue
@@ -10,7 +10,7 @@ defineProps({
 </script>
 
 <template>
-  <div class="card">
+  <div class="card" v-reveal-on-scroll>
     <h3>{{ card.title }}</h3>
     <div class="card-company">
       <i class="pi pi-briefcase"></i>

--- a/src/modules/home/modules/featured-projects/components/ProjectCard.vue
+++ b/src/modules/home/modules/featured-projects/components/ProjectCard.vue
@@ -10,7 +10,7 @@ defineProps({
 </script>
 
 <template>
-  <div class="card">
+  <div class="card" v-reveal-on-scroll>
     <img
         class="card-img"
         :src="project.img"

--- a/src/modules/home/modules/reviews/components/ReviewCart.vue
+++ b/src/modules/home/modules/reviews/components/ReviewCart.vue
@@ -12,7 +12,7 @@ defineProps({
 </script>
 
 <template>
-  <div class="card">
+  <div class="card" v-reveal-on-scroll>
     <img src="/icons/review.svg" alt="">
     <p>{{ card.text }}</p>
     <Rating :default-value="card.rating" class="card-rating"/>

--- a/src/modules/home/modules/skills/components/SkillCard.vue
+++ b/src/modules/home/modules/skills/components/SkillCard.vue
@@ -10,7 +10,7 @@ defineProps({
 </script>
 
 <template>
-  <div class="card">
+  <div class="card" v-reveal-on-scroll>
     <div class="card-header">
       <div class="card-iconWrapper">
         <img :src="'/icons/' + skill.icon" alt="frontend" width="24">


### PR DESCRIPTION
### Motivation
- Provide a simple scroll-triggered reveal animation for cards so section items animate into view when they enter the viewport.
- Keep the implementation lightweight and reusable across card components using a single directive.
- Respect user motion preferences by supporting `prefers-reduced-motion` to disable transitions.

### Description
- Add a global Vue directive `v-reveal-on-scroll` in `src/main.ts` that uses `IntersectionObserver` to toggle the `is-visible` class and unobserve targets after reveal.
- Add shared reveal styles in `src/assets/styles/global.scss` including transitions and `prefers-reduced-motion` handling for accessibility.
- Apply the `v-reveal-on-scroll` directive to card components: `SkillCard.vue`, `ExperienceCard.vue`, `ProjectCard.vue`, and `ReviewCart.vue` so they animate when scrolled into view.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, indicating the app served successfully.
- Attempted a browser smoke test with Playwright to capture a screenshot after scrolling, but the Playwright navigation failed with `ERR_CONNECTION_REFUSED` so the visual verification did not complete.
- No unit or integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948a35b60d88326b29b8b939f5d4e11)