### PR TITLE
Improve mobile responsiveness across home sections

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -23,6 +23,13 @@ body {
   max-width: 1000px;
   margin: 0 auto;
   background-color: #fff;
+  width: 100%;
+}
+
+@media (max-width: 900px) {
+  .container {
+    max-width: 100%;
+  }
 }
 
 .reveal-on-scroll {

--- a/src/modules/home/modules/contact-form/ContactFormView.vue
+++ b/src/modules/home/modules/contact-form/ContactFormView.vue
@@ -40,5 +40,20 @@ import ContactForm from './components/ContactForm.vue'
     justify-content: space-between;
     gap: 48px;
   }
+
+  @media (max-width: 768px) {
+    &__title {
+      font-size: 30px;
+    }
+
+    &__subtitle {
+      margin-bottom: 32px;
+    }
+
+    &__content {
+      flex-direction: column;
+      gap: 24px;
+    }
+  }
 }
 </style>

--- a/src/modules/home/modules/contact-form/components/ContactForm.vue
+++ b/src/modules/home/modules/contact-form/components/ContactForm.vue
@@ -102,5 +102,9 @@ function sendForm() {
 
   &__submit {
   }
+
+  @media (max-width: 768px) {
+    width: 100%;
+  }
 }
 </style>

--- a/src/modules/home/modules/contact-form/components/contact-information.vue
+++ b/src/modules/home/modules/contact-form/components/contact-information.vue
@@ -93,5 +93,11 @@ const location = 'San Francisco, CA'
       text-decoration: underline;
     }
   }
+
+  @media (max-width: 768px) {
+    &__list {
+      gap: 20px;
+    }
+  }
 }
 </style>

--- a/src/modules/home/modules/experience/ExperienceView.vue
+++ b/src/modules/home/modules/experience/ExperienceView.vue
@@ -36,5 +36,15 @@ import {EXPERIENCE_LIST} from "./constants";
     flex-direction: column;
     gap: 16px;
   }
+
+  @media (max-width: 768px) {
+    h2 {
+      font-size: 30px;
+    }
+
+    p {
+      margin-bottom: 24px;
+    }
+  }
 }
 </style>

--- a/src/modules/home/modules/experience/components/ExperienceCard.vue
+++ b/src/modules/home/modules/experience/components/ExperienceCard.vue
@@ -32,6 +32,7 @@ defineProps({
   &-skills {
     display: flex;
     gap: 16px;
+    flex-wrap: wrap;
   }
 
   &-description {
@@ -57,6 +58,10 @@ defineProps({
   p {
     font-size: 14px;
     color: #606060;
+  }
+
+  @media (max-width: 768px) {
+    padding: 12px;
   }
 }
 </style>

--- a/src/modules/home/modules/featured-projects/FeaturedProjectsView.vue
+++ b/src/modules/home/modules/featured-projects/FeaturedProjectsView.vue
@@ -33,7 +33,24 @@ import {PROJECTS} from "./constants";
 
   &-cards {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 24px;
+    flex-wrap: wrap;
+  }
+
+  @media (max-width: 768px) {
+    h2 {
+      font-size: 30px;
+    }
+
+    p {
+      margin-bottom: 24px;
+    }
+
+    &-cards {
+      flex-direction: column;
+      align-items: center;
+    }
   }
 }
 </style>

--- a/src/modules/home/modules/featured-projects/components/ProjectCard.vue
+++ b/src/modules/home/modules/featured-projects/components/ProjectCard.vue
@@ -28,6 +28,7 @@ defineProps({
 <style scoped lang="scss">
 .card {
   max-width: 300px;
+  width: 100%;
   border-radius: 16px;
   overflow: hidden;
   -webkit-box-shadow: 0px 0px 21px 7px rgba(34, 60, 80, 0.2);
@@ -50,6 +51,7 @@ defineProps({
   &-img {
     width: 100%;
     height: 180px;
+    object-fit: cover;
   }
 
   &-title {
@@ -70,6 +72,14 @@ defineProps({
     flex-wrap: wrap;
     gap: 8px;
     color: grey;
+  }
+
+  @media (max-width: 768px) {
+    max-width: 100%;
+
+    &-img {
+      height: 160px;
+    }
   }
 }
 </style>

--- a/src/modules/home/modules/header/HeaderView.vue
+++ b/src/modules/home/modules/header/HeaderView.vue
@@ -16,5 +16,12 @@ import UiHeaderIInfoBlock from "./components/UiHeaderIInfoBlock.vue";
   display: flex;
   gap: 44px;
   justify-content: space-between;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    text-align: center;
+  }
 }
 </style>

--- a/src/modules/home/modules/header/components/UiAvatar.vue
+++ b/src/modules/home/modules/header/components/UiAvatar.vue
@@ -18,5 +18,11 @@
     text-align: center;
     color: gray;
   }
+
+  @media (max-width: 768px) {
+    &-img {
+      width: 140px;
+    }
+  }
 }
 </style>

--- a/src/modules/home/modules/header/components/UiHeaderIInfoBlock.vue
+++ b/src/modules/home/modules/header/components/UiHeaderIInfoBlock.vue
@@ -63,5 +63,25 @@ import Button from 'primevue/button';
     display: flex;
     gap: 16px;
   }
+
+  @media (max-width: 768px) {
+    align-items: center;
+    text-align: center;
+
+    h1 {
+      font-size: 28px;
+    }
+
+    &-socials {
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    &-actions {
+      width: 100%;
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
 }
 </style>

--- a/src/modules/home/modules/reviews/ReviewsView.vue
+++ b/src/modules/home/modules/reviews/ReviewsView.vue
@@ -33,9 +33,25 @@ import {REVIEWS} from "./constants";
 
   &-cards {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     width: 100%;
     gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  @media (max-width: 768px) {
+    h2 {
+      font-size: 30px;
+    }
+
+    p {
+      margin-bottom: 24px;
+    }
+
+    &-cards {
+      flex-direction: column;
+      align-items: stretch;
+    }
   }
 }
 </style>

--- a/src/modules/home/modules/reviews/components/ReviewCart.vue
+++ b/src/modules/home/modules/reviews/components/ReviewCart.vue
@@ -29,6 +29,7 @@ defineProps({
 
 <style scoped lang="scss">
 .card {
+  width: 100%;
   img {
     margin-bottom: 16px;
   }
@@ -67,6 +68,10 @@ defineProps({
         font-size: 12px;
       }
     }
+  }
+
+  @media (max-width: 768px) {
+    padding: 16px;
   }
 }
 </style>

--- a/src/modules/home/modules/skills/SkillsView.vue
+++ b/src/modules/home/modules/skills/SkillsView.vue
@@ -36,5 +36,25 @@ import {SKILLS} from "./constants";
     gap: 24px;
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
+
+  @media (max-width: 900px) {
+    &-cards {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 768px) {
+    h2 {
+      font-size: 30px;
+    }
+
+    p {
+      margin-bottom: 24px;
+    }
+
+    &-cards {
+      grid-template-columns: 1fr;
+    }
+  }
 }
 </style>

--- a/src/modules/home/modules/skills/components/SkillCard.vue
+++ b/src/modules/home/modules/skills/components/SkillCard.vue
@@ -29,6 +29,7 @@ defineProps({
   border-radius: 12px;
   border: solid 2px oklch(0.93 0.01 2.1);
   max-width: 305px;
+  width: 100%;
 
   h4 {
     color: oklch(.21 .034 264.665);
@@ -61,6 +62,10 @@ defineProps({
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
+  }
+
+  @media (max-width: 768px) {
+    max-width: 100%;
   }
 }
 </style>

--- a/src/modules/home/view/HomeView.vue
+++ b/src/modules/home/view/HomeView.vue
@@ -10,15 +10,15 @@ import ContactFormView from "../modules/contact-form/ContactFormView.vue";
 <template>
   <div class="home">
     <HeaderView/>
-    <img src="/icons/arrow-down.gif" alt="arrow" width="50">
+    <img class="home-arrow" src="/icons/arrow-down.gif" alt="arrow" width="50">
     <FeaturedProjectsView/>
-    <img src="/icons/arrow-down.gif" alt="arrow" width="50">
+    <img class="home-arrow" src="/icons/arrow-down.gif" alt="arrow" width="50">
     <SkillsView/>
-    <img src="/icons/arrow-down.gif" alt="arrow" width="50">
+    <img class="home-arrow" src="/icons/arrow-down.gif" alt="arrow" width="50">
     <ExperienceView/>
-    <img src="/icons/arrow-down.gif" alt="arrow" width="50">
+    <img class="home-arrow" src="/icons/arrow-down.gif" alt="arrow" width="50">
     <ReviewsView/>
-    <img src="/icons/arrow-down.gif" alt="arrow" width="50">
+    <img class="home-arrow" src="/icons/arrow-down.gif" alt="arrow" width="50">
     <ContactFormView/>
   </div>
 </template>
@@ -29,8 +29,17 @@ import ContactFormView from "../modules/contact-form/ContactFormView.vue";
   flex-direction: column;
   gap: 56px;
   padding: 24px;
-  img {
+  &-arrow {
     margin: 0 auto;
+  }
+
+  @media (max-width: 768px) {
+    gap: 36px;
+    padding: 16px;
+
+    &-arrow {
+      width: 36px;
+    }
   }
 }
 </style>


### PR DESCRIPTION
### Motivation
- Make the site's home layout usable and visually consistent on mobile devices by adjusting spacing, sizes and stacking behavior.
- Ensure header, avatar, project/skill/review cards and contact form adapt to narrow viewports without overflow.

### Description
- Added responsive container sizing and media query rules in `src/assets/styles/global.scss` to allow full-width behaviour under 900px.
- Updated `HomeView.vue` to use a dedicated `.home-arrow` class and reduced spacing for mobile, and added responsive rules to several sections for smaller gaps and paddings.
- Converted header layout to a stacked, centered layout under 768px and reduced avatar size in `UiAvatar.vue` while making header info (`UiHeaderIInfoBlock.vue`) center-align and stack socials/actions on mobile.
- Made cards and lists responsive by setting card widths to `100%`, adding `flex-wrap`/`grid` fallbacks, tuning image `object-fit`, and adjusting typography in `featured-projects`, `skills`, `experience`, `reviews`, and `contact-form` components.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server reported ready.
- Ran an automated Playwright script that opened a mobile viewport and saved a screenshot to `artifacts/mobile-home.png`, which completed successfully.
- No automated unit or integration tests were executed against these style changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae90ae8148326a5175483470f90dd)